### PR TITLE
Use env vars for DB connection

### DIFF
--- a/backend/src/backend/ConexionBD.java
+++ b/backend/src/backend/ConexionBD.java
@@ -8,29 +8,54 @@ package backend;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 
 public class ConexionBD {
 
-  // URL de conexión JDBC a la base de datos MySQL local 'todo_app' en el puerto 3306
-  private static final String URL = "jdbc:mysql://localhost:3306/todo_app";
-   // Usuario y contraseña para acceder a la base de datos
-  private static final String USUARIO = "root";
-  private static final String CONTRASENA = "root";
+  private static final String DEFAULT_URL = "jdbc:mysql://localhost:3306/todo_app";
+  private static final String DEFAULT_USER = "root";
+  private static final String DEFAULT_PASSWORD = "root";
 
-   /**
-   * Método estático para obtener una conexión a la base de datos
-   * @return Connection objeto que representa la conexión, o null si falla
-   */
-  
-  public static Connection conectar() {
-    try {
-      Connection conn = DriverManager.getConnection(URL, USUARIO, CONTRASENA);
-      System.out.println("✅ Conexión establecida con la base de datos.");
-      return conn;
-    } catch (SQLException e) {
-      System.out.println("❌ Error al conectar: " + e.getMessage());
-      return null;
+  private static final String URL;
+  private static final String USUARIO;
+  private static final String CONTRASENA;
+
+  static {
+    String url = System.getenv("DB_URL");
+    String user = System.getenv("DB_USER");
+    String pass = System.getenv("DB_PASSWORD");
+
+    if (url == null || user == null || pass == null) {
+      Properties props = new Properties();
+      try (InputStream in = ConexionBD.class.getClassLoader().getResourceAsStream("db.properties")) {
+        if (in != null) {
+          props.load(in);
+          if (url == null) url = props.getProperty("db.url");
+          if (user == null) user = props.getProperty("db.user");
+          if (pass == null) pass = props.getProperty("db.password");
+        }
+      } catch (IOException e) {
+        System.out.println("⚠️ No se pudo cargar db.properties: " + e.getMessage());
+      }
     }
+
+    URL = url != null ? url : DEFAULT_URL;
+    USUARIO = user != null ? user : DEFAULT_USER;
+    CONTRASENA = pass != null ? pass : DEFAULT_PASSWORD;
+  }
+
+  /**
+   * Obtiene una conexión a la base de datos.
+   *
+   * @return Connection objeto que representa la conexión
+   * @throws SQLException si ocurre un problema al conectar
+   */
+  public static Connection conectar() throws SQLException {
+    Connection conn = DriverManager.getConnection(URL, USUARIO, CONTRASENA);
+    System.out.println("✅ Conexión establecida con la base de datos.");
+    return conn;
   }
 
 }

--- a/backend/src/backend/db.properties
+++ b/backend/src/backend/db.properties
@@ -1,0 +1,3 @@
+db.url=jdbc:mysql://localhost:3306/todo_app
+db.user=root
+db.password=root


### PR DESCRIPTION
## Summary
- configure `ConexionBD` to read DB settings from environment or `db.properties`
- throw an exception if the DB connection fails
- keep DAO methods using the connection and propagate the exception
- provide default `db.properties`

## Testing
- `javac -d backend/classes backend/src/backend/*.java` *(fails: package com.google.gson does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68643c7e48b4832694164842f8141159